### PR TITLE
Fix Issue #60 Time Frequency Based Rolling Window

### DIFF
--- a/pandarallel/data_types/rolling_groupby.py
+++ b/pandarallel/data_types/rolling_groupby.py
@@ -1,5 +1,9 @@
 import itertools
+from datetime import timedelta
+
 import pandas as pd
+from pandas.tseries.frequencies import to_offset
+
 from pandarallel.utils.tools import chunk, PROGRESSION
 
 
@@ -18,13 +22,22 @@ class RollingGroupBy:
 
     @staticmethod
     def att2value(rolling):
-        return {
+        attributes = {
             attribute: getattr(rolling, attribute) for attribute in rolling._attributes
         }
 
+        # Fix window for win_type = freq, because then it was defined by the user in a format like '1D' and refers
+        # to a time window rolling
+        if 'win_type' in attributes and attributes['win_type'] == 'freq':
+            window = to_offset(timedelta(microseconds=int(attributes["window"] / 1000)))
+            attributes['window'] = window
+            attributes.pop("win_type")
+
+        return attributes
+
     @staticmethod
     def worker(
-        tuples, index, attribute2value, queue, progress_bar, func, *args, **kwargs
+            tuples, index, attribute2value, queue, progress_bar, func, *args, **kwargs
     ):
         # TODO: See if this pd.concat is avoidable
         results = []

--- a/pandarallel/pandarallel.py
+++ b/pandarallel/pandarallel.py
@@ -576,5 +576,5 @@ class pandarallel:
 
         # Rolling GroupBy
         args = bargs_prog_worker + (RGB.get_chunks, RGB.worker, RGB.reduce)
-        kwargs = dict(get_worker_meta_args=SR.att2value)
+        kwargs = dict(get_worker_meta_args=RGB.att2value)
         RollingGroupby.parallel_apply = parallelize(*args, **kwargs)

--- a/tests/test_pandarallel.py
+++ b/tests/test_pandarallel.py
@@ -63,7 +63,7 @@ def func_series_apply(request):
     return dict(
         named=func,
         anonymous=lambda x, power, bias=0: math.log10(math.sqrt(math.exp(x ** power)))
-        + bias,
+                                           + bias,
     )[request.param]
 
 
@@ -75,9 +75,9 @@ def func_series_rolling_apply(request):
     return dict(
         named=func,
         anonymous=lambda x: x.iloc[0]
-        + x.iloc[1] ** 2
-        + x.iloc[2] ** 3
-        + x.iloc[3] ** 4,
+                            + x.iloc[1] ** 2
+                            + x.iloc[2] ** 3
+                            + x.iloc[3] ** 4,
     )[request.param]
 
 
@@ -101,15 +101,15 @@ def func_dataframe_groupby_rolling_apply(request):
     return dict(
         named=func,
         anonymous=lambda x: x.iloc[0]
-        + x.iloc[1] ** 2
-        + x.iloc[2] ** 3
-        + x.iloc[3] ** 4,
+                            + x.iloc[1] ** 2
+                            + x.iloc[2] ** 3
+                            + x.iloc[3] ** 4,
     )[request.param]
 
 
 @pytest.fixture()
 def pandarallel_init(progress_bar, use_memory_fs):
-    pandarallel.initialize(progress_bar=progress_bar, use_memory_fs=use_memory_fs)
+    pandarallel.initialize(progress_bar=progress_bar, use_memory_fs=use_memory_fs, nb_workers=2)
 
 
 def test_dataframe_apply_axis_0(pandarallel_init, func_dataframe_apply_axis_0):
@@ -206,7 +206,7 @@ def test_dataframe_groupby_apply(pandarallel_init, func_dataframe_groupby_apply)
 
 
 def test_dataframe_groupby_rolling_apply(
-    pandarallel_init, func_dataframe_groupby_rolling_apply
+        pandarallel_init, func_dataframe_groupby_rolling_apply
 ):
     df_size = int(1e2)
     df = pd.DataFrame(
@@ -215,12 +215,34 @@ def test_dataframe_groupby_rolling_apply(
 
     res = (
         df.groupby("a")
-        .b.rolling(4)
-        .apply(func_dataframe_groupby_rolling_apply, raw=False)
+            .b.rolling(4)
+            .apply(func_dataframe_groupby_rolling_apply, raw=False)
     )
     res_parallel = (
         df.groupby("a")
-        .b.rolling(4)
-        .parallel_apply(func_dataframe_groupby_rolling_apply, raw=False)
+            .b.rolling(4)
+            .parallel_apply(func_dataframe_groupby_rolling_apply, raw=False)
     )
     res.equals(res_parallel)
+
+
+def test_datetime_rolling(pandarallel_init):
+    from datetime import datetime
+    test_df = pd.DataFrame([{"datetime": datetime.now(), "A": 1, "B": 7},
+                            {"datetime": datetime.now(), "A": 2, "B": 4}])
+
+    grouped_test_df = test_df.set_index('datetime').groupby('A')
+
+    interval = '1D'
+
+    res = (grouped_test_df.rolling(interval)
+           .B
+           .parallel_apply(np.sum))
+
+    res_parallel = (grouped_test_df.rolling(interval)
+                    .B
+                    .parallel_apply(np.sum))
+
+    res.equals(res_parallel)
+
+:q


### PR DESCRIPTION
Because of pandas internal representation of time frequency based rolling windows . pandarallel was not able to reconstruct the window definition appropriately. This is now fixed by handling this special case in the `RollingGroupBy` `att2value` method.  Looking forward to feedback.