### PR TITLE
Fix issue #45 DataFrameGroupBy.parallel_apply returns incorrect results

### DIFF
--- a/pandarallel/pandarallel.py
+++ b/pandarallel/pandarallel.py
@@ -571,7 +571,7 @@ class pandarallel:
 
         # DataFrame GroupBy
         args = bargs_prog_func + (DFGB.get_chunks, DFGB.worker, DFGB.reduce)
-        kwargs = dict(get_reduce_meta_args=DFGB.get_index)
+        kwargs = dict(get_reduce_meta_args=DFGB.get_reduce_meta_args)
         DataFrameGroupBy.parallel_apply = parallelize(*args, **kwargs)
 
         # Rolling GroupBy


### PR DESCRIPTION
Index is now constructed correctly when combining results of DataFrame split-apply operation. Modeled after https://github.com/pandas-dev/pandas/blob/7c94949dc89c62cae1bc647acd87266d6c3a0468/pandas/core/groupby/ops.py#L187 and https://github.com/pandas-dev/pandas/blob/7c94949dc89c62cae1bc647acd87266d6c3a0468/pandas/core/groupby/groupby.py#L750