### PR TITLE
Fix #63 by adding an alternative way to wrap progress_pre_func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 *.egg-info
 .mypy_cache
 .pytest_cache
+.idea/
+venv/


### PR DESCRIPTION
Add a flag to use python-style wrapping for the progress_pre_func. This should help in the cases when bytecode inlining does not work well.

Open questions:
* Is it desirable to add an automatic switch so pandarallel would handle the situation with no additional configuration?
* Is there any good way to cover this switch by tests?
* As @MarvinT [mentioned](https://github.com/nalepae/pandarallel/issues/63#issuecomment-576876714), how about to create another issue and use tqdm instead of a custom progress bar, so pandarallel could focus on parallel execution?