### PR TITLE
Ensure pool is properly closed

### DIFF
--- a/pandarallel/pandarallel.py
+++ b/pandarallel/pandarallel.py
@@ -438,13 +438,9 @@ def parallelize(
         nb_workers = len(chunk_lengths)
 
         try:
-            pool = Pool(
-                nb_workers, worker_init, (prepare_worker(use_memory_fs)(worker),),
-            )
-
-            map_result = pool.map_async(global_worker, workers_args)
-            pool.close()
-
+            with Pool(nb_workers, worker_init, (prepare_worker(use_memory_fs)(worker),), ) as pool:
+                map_result = pool.map_async(global_worker, workers_args)
+    
             results = get_workers_result(
                 use_memory_fs,
                 nb_workers,


### PR DESCRIPTION
First of all, I really like your project and it saves me lots of time. However, I sometime aborted my code to fix some issues and  found that workers were still alive and occupied the resources. This causes some issues when I try to use other multiprocessing modules. Hence, I would like to suggest the following syntax to ensure the pool is closed properly. 

Use context manager syntax to ensure the Pool is closed properly if the user abort the execution before the execution is done. This can kill all workers when users abort the execution.