### PR TITLE
fix axis=0 parallel_apply with data frame as an outcome

### DIFF
--- a/pandarallel/data_types/dataframe_groupby.py
+++ b/pandarallel/data_types/dataframe_groupby.py
@@ -5,7 +5,7 @@ from pandarallel.utils.tools import chunk, df_indexed_like
 
 class DataFrameGroupBy:
     @staticmethod
-    def get_reduce_meta_args(df_grouped):
+    def get_reduce_meta_args(df_grouped, _):
         return df_grouped
 
     @staticmethod


### PR DESCRIPTION
Solves the axis=0 problem. Fixes #74.

This was caused by a wrong `concat` in dataframe reduce function.

To make this work with other classes, I had to change a few more lines.

All tests have been executed and finish without error.

May not be the nicest, final solution, but a starting point.

Cheers,
Markus