### PR TITLE
Fix #191: `TypeError: 'generator' object is not subscriptable` when using colab

### DIFF
--- a/pandarallel/__init__.py
+++ b/pandarallel/__init__.py
@@ -1,3 +1,3 @@
 from .core import pandarallel
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"

--- a/pandarallel/data_types/dataframe.py
+++ b/pandarallel/data_types/dataframe.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, Dict, Iterable, Iterator
+from types import GeneratorType
 
 import pandas as pd
 
@@ -44,6 +45,8 @@ class DataFrame:
         def reduce(
             datas: Iterable[pd.DataFrame], extra: Dict[str, Any]
         ) -> pd.DataFrame:
+            if isinstance(datas, GeneratorType):
+                datas = list(datas)
             axis = 0 if isinstance(datas[0], pd.Series) else 1 - extra["axis"]
             return pd.concat(datas, copy=False, axis=axis)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ author = Manu NALEPA
 author_email = nalepae@gmail.com
 license = BSD
 license_file = LICENSE
-version = 1.6.2
+version = 1.6.3
 
 classifiers =
     License :: OSI Approved :: BSD License


### PR DESCRIPTION
Fix #191 
Didn't find a way of doing this that doesn't convert the generator to a list, unfortunately.

To check that it works in colab (adapted from @agiveon's example):
```python
!pip install -U --no-cache-dir https://github.com/till-m/pandarallel/archive/fix191.zip
from pandarallel import pandarallel
pandarallel.initialize(progress_bar=True)

import pandas as pd

data = {'Name': ['Tom', 'Joseph', 'Krish', 'John'], 'Age': [20, 21, 19, 18]}
df = pd.DataFrame(data)
df['HalfAge'] = df.parallel_apply(lambda r: r.Age/2,axis=1)
```
