### PR TITLE
Fix 178

### DIFF
--- a/pandarallel/core.py
+++ b/pandarallel/core.py
@@ -332,6 +332,11 @@ def parallelize_with_memory_file_system(
                 # saved at all. 
                 results_promise.get()
 
+                # If the above statement does not raise an exception, that
+                # means the multiprocessing went well and we want to re-raise
+                # the original EOFError.
+                raise
+
         finally:
             for output_file in output_files:
                 # When pandarallel stop supporting Python 3.7 and older, replace this

--- a/pandarallel/core.py
+++ b/pandarallel/core.py
@@ -292,7 +292,7 @@ def parallelize_with_memory_file_system(
             ]
 
             pool = CONTEXT.Pool(nb_workers)
-            pool.starmap_async(wrapped_work_function, work_args_list)
+            results_promise = pool.starmap_async(wrapped_work_function, work_args_list)
 
             pool.close()
 
@@ -321,10 +321,16 @@ def parallelize_with_memory_file_system(
                     progress_bars.set_error(worker_index)
                     progress_bars.update(progresses)
 
-            return wrapped_reduce_function(
-                (Path(output_file.name) for output_file in output_files),
-                reduce_extra,
-            )
+            try:
+                return wrapped_reduce_function(
+                    (Path(output_file.name) for output_file in output_files),
+                    reduce_extra,
+                )
+            except EOFError:
+                # Loading the files failed, this most likely means that there
+                # was some error during processing and the files were never
+                # saved at all. 
+                results_promise.get()
 
         finally:
             for output_file in output_files:

--- a/tests/test_pandarallel.py
+++ b/tests/test_pandarallel.py
@@ -1,4 +1,3 @@
-from decimal import DivisionByZero
 import math
 
 import numpy as np
@@ -22,7 +21,7 @@ def use_memory_fs(request):
     return request.param
 
 
-@pytest.fixture(params=(RuntimeError, AttributeError, DivisionByZero))
+@pytest.fixture(params=(RuntimeError, AttributeError, ZeroDivisionError))
 def exception(request):
     return request.param
 


### PR DESCRIPTION
Fix #178

```python
import pandas as pd
from pandarallel import pandarallel

data = pd.Series(list(range(1, 100000)))

pandarallel.initialize(progress_bar=True)
# INFO: Pandarallel will run on 8 workers.
# INFO: Pandarallel will use Memory file system to transfer data between the main process and workers.

data.parallel_apply(lambda a: a / 0)
```

Output
```
INFO: Pandarallel will run on 2 workers.
INFO: Pandarallel will use Memory file system to transfer data between the main process and workers.
   0.00%                                          |        0 /    50000 |      
   0.00%                                          |        0 /    49999 |      ---------------------------------------------------------------------------
RemoteTraceback                           Traceback (most recent call last)
RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 51, in starmapstar
    return list(itertools.starmap(args[0], args[1]))
  File "/home/t/pandarallel/pandarallel/core.py", line 95, in __call__
    result = self.work_function(
  File "/home/t/pandarallel/pandarallel/data_types/series.py", line 26, in work
    return data.apply(
  File "/home/t/.virtualenvs/pandarallel/lib/python3.10/site-packages/pandas/core/series.py", line 4433, in apply
    return SeriesApply(self, func, convert_dtype, args, kwargs).apply()
  File "/home/t/.virtualenvs/pandarallel/lib/python3.10/site-packages/pandas/core/apply.py", line 1088, in apply
    return self.apply_standard()
  File "/home/t/.virtualenvs/pandarallel/lib/python3.10/site-packages/pandas/core/apply.py", line 1143, in apply_standard
    mapped = lib.map_infer(
  File "pandas/_libs/lib.pyx", line 2870, in pandas._libs.lib.map_infer
  File "/home/t/pandarallel/pandarallel/progress_bars.py", line 210, in closure
    return user_defined_function(
  File "<ipython-input-1-346a52584205>", line -1, in <lambda>
ZeroDivisionError: division by zero
"""

The above exception was the direct cause of the following exception:

ZeroDivisionError                         Traceback (most recent call last)
Input In [1], in <cell line: 10>()
      6 pandarallel.initialize(progress_bar=True)
      7 # INFO: Pandarallel will run on 8 workers.
      8 # INFO: Pandarallel will use Memory file system to transfer data between the main process and workers.
---> 10 data.parallel_apply(lambda a: a / 0)

File ~/pandarallel/pandarallel/core.py:333, in parallelize_with_memory_file_system.<locals>.closure(data, user_defined_function, *user_defined_function_args, **user_defined_function_kwargs)
    325         return wrapped_reduce_function(
    326             (Path(output_file.name) for output_file in output_files),
    327             reduce_extra,
    328         )
    329     except EOFError:
    330         # Loading the files failed, this most likely means that there
    331         # was some error during processing and the files were never
    332         # saved at all. 
--> 333         results_promise.get()
    335 finally:
    336     for output_file in output_files:
    337         # When pandarallel stop supporting Python 3.7 and older, replace this
    338         # try/except clause by:
    339         # Path(output_file.name).unlink(missing_ok=True)

File /usr/lib/python3.10/multiprocessing/pool.py:771, in ApplyResult.get(self, timeout)
    769     return self._value
    770 else:
--> 771     raise self._value

ZeroDivisionError: division by zero
```

This isn't the most informative stack trace, but it should be a significant improvement over the old `EOFError`.
