### PR TITLE
Add option to show single progress bar for all workers

### DIFF
--- a/pandarallel/progress_bars.py
+++ b/pandarallel/progress_bars.py
@@ -54,8 +54,11 @@ def is_notebook_lab() -> bool:
 
 
 class ProgressBarsConsole(ProgressBars):
-    def __init__(self, maxs: List[int], show: bool) -> None:
+    def __init__(self, maxs: List[int], show: bool, single_bar=True) -> None:
         self.__show = show
+        self.__single_bar = single_bar
+        if self.__single_bar:
+            maxs = [sum(maxs)]
         self.__bars = [[0, max] for max in maxs]
         self.__width = self.__get_width()
 
@@ -107,6 +110,8 @@ class ProgressBarsConsole(ProgressBars):
         if not self.__show:
             return
 
+        if self.__single_bar:
+            values = [sum(values)]
         for index, value in enumerate(values):
             self.__bars[index][0] = value
 
@@ -118,7 +123,7 @@ class ProgressBarsConsole(ProgressBars):
 
 
 class ProgressBarsNotebookLab(ProgressBars):
-    def __init__(self, maxs: List[int], show: bool) -> None:
+    def __init__(self, maxs: List[int], show: bool, single_bar=True) -> None:
         """Initialization.
         Positional argument:
         maxs - List containing the max value of each progress bar
@@ -131,6 +136,9 @@ class ProgressBarsNotebookLab(ProgressBars):
         from IPython.display import display
         from ipywidgets import HBox, IntProgress, Label, VBox
 
+        self.__single_bar = single_bar
+        if self.__single_bar:
+            maxs = [sum(maxs)]
         self.__bars = [
             HBox(
                 [
@@ -150,7 +158,8 @@ class ProgressBarsNotebookLab(ProgressBars):
         """
         if not self.__show:
             return
-
+        if self.__single_bar:
+            values = [sum(values)]
         for index, value in enumerate(values):
             bar, label = self.__bars[index].children
 
@@ -172,12 +181,13 @@ class ProgressBarsNotebookLab(ProgressBars):
 
 
 def get_progress_bars(
-    maxs: List[int], show
+    maxs: List[int], show, single_bar
 ) -> Union[ProgressBarsNotebookLab, ProgressBarsConsole]:
+    print(f"Single progress bar: {single_bar}")
     return (
-        ProgressBarsNotebookLab(maxs, show)
+        ProgressBarsNotebookLab(maxs, show, single_bar)
         if is_notebook_lab()
-        else ProgressBarsConsole(maxs, show)
+        else ProgressBarsConsole(maxs, show, single_bar)
     )
 
 

--- a/pandarallel/progress_bars.py
+++ b/pandarallel/progress_bars.py
@@ -183,7 +183,6 @@ class ProgressBarsNotebookLab(ProgressBars):
 def get_progress_bars(
     maxs: List[int], show, single_bar
 ) -> Union[ProgressBarsNotebookLab, ProgressBarsConsole]:
-    print(f"Single progress bar: {single_bar}")
     return (
         ProgressBarsNotebookLab(maxs, show, single_bar)
         if is_notebook_lab()

--- a/pandarallel/progress_bars.py
+++ b/pandarallel/progress_bars.py
@@ -175,7 +175,7 @@ class ProgressBarsNotebookLab(ProgressBars):
         """Set a bar on error"""
         if not self.__show:
             return
-
+        if self.__single_bar: index = 0
         bar, _ = self.__bars[index].children
         bar.bar_style = "danger"
 


### PR DESCRIPTION
As of now, each worker has its own progress bar, but it would be nice to have a summary bar for all workers, since sometimes it will be too cluttered to show all progress bars when the number of workers are too high, as mentioned in https://github.com/nalepae/pandarallel/issues/134

I implemented this feature to allow users to pass an argument to `pandarallel.initialize` to select to use only one progress bar. The test results are shown below:
![image](https://user-images.githubusercontent.com/13659369/188935639-3d2b2ffa-77ef-49f7-8354-7e82407b6be2.png)
