### PR TITLE
Fix pandas `FutureWarning` about series chunking

### DIFF
--- a/pandarallel/data_types/series.py
+++ b/pandarallel/data_types/series.py
@@ -13,7 +13,7 @@ class Series:
             nb_workers: int, data: pd.Series, **kwargs
         ) -> Iterator[pd.Series]:
             for chunk_ in chunk(data.size, nb_workers):
-                yield data[chunk_]
+                yield data.iloc[chunk_]
 
         @staticmethod
         def work(
@@ -39,7 +39,7 @@ class Series:
             nb_workers: int, data: pd.Series, **kwargs
         ) -> Iterator[pd.Series]:
             for chunk_ in chunk(data.size, nb_workers):
-                yield data[chunk_]
+                yield data.iloc[chunk_]
 
         @staticmethod
         def work(


### PR DESCRIPTION
Fixes the following `FutureWarning` emitted by `pandas` (1.5.1).

```
/.../lib/python3.10/site-packages/pandarallel/data_types/series.py:42: FutureWarning:
The behavior of `series[i:j]` with an integer-dtype index is deprecated. In a future version, this will be
treated as *label-based* indexing, consistent with e.g. `series[i]` lookups. To retain the old behavior,
use `series.iloc[i:j]`. To get the future behavior, use `series.loc[i:j]`.
  yield data[chunk_]
```