### PR TITLE
Fix #197

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,26 +15,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        # Remove Python 3.7.13 on 27 Jun 2023: https://endoflife.date/python
-        python-version: ["3.7.13", "3.8.13", "3.9.13", "3.10.5"]
+        os: ["ubuntu-20.04", "macos-latest", "windows-latest"]
+        # Remove Python 3.7.9 on 27 Jun 2023: https://endoflife.date/python
+        python-version: ["3.7.9", "3.8.10", "3.9.13", "3.10.8"]
         pandas-version: ["1.0.5", "1.1.5", "1.2.5", "1.3.5", "1.4.3", ""]
 
         exclude:
           # Pandas 1.4.3 requires Python >= 3.8
-          - python-version: "3.7.13"
+          - python-version: "3.7.9"
             pandas-version: "1.4.3"
           # Pandas 1.0.5 has to be fully rebuilt with Python >= 3.9.13 (taking > 10 min)
           - python-version: "3.9.13"
             pandas-version: "1.0.5"
           # Pandas 1.0.5 has to be fully rebuilt with Python >= 3.9.13 (taking > 10 min)
-          - python-version: "3.10.5"
+          - python-version: "3.10.8"
             pandas-version: "1.0.5"
           # Pandas 1.1.5 has to be fully rebuilt with Python >= 3.10.5 (taking > 10 min)
-          - python-version: "3.10.5"
+          - python-version: "3.10.8"
             pandas-version: "1.1.5"
           # Pandas 1.2.5 has to be fully rebuilt with Python >= 3.10.5 (taking > 10 min)
-          - python-version: "3.10.5"
+          - python-version: "3.10.8"
             pandas-version: "1.2.5"
 
     steps:

--- a/pandarallel/progress_bars.py
+++ b/pandarallel/progress_bars.py
@@ -5,11 +5,12 @@ import sys
 from abc import ABC, abstractmethod
 from enum import Enum
 from itertools import count
-from time import time
+from time import time_ns
 from typing import Callable, List, Union
 
 from .utils import WorkerStatus
 
+INTERVAL_NS = 250_000_000  # 0.25 sec
 MINIMUM_TERMINAL_WIDTH = 72
 
 
@@ -37,7 +38,7 @@ class ProgressState:
     def __init__(self, chunk_size: int) -> None:
         self.last_put_iteration = 0
         self.next_put_iteration = max(chunk_size // 100, 1)
-        self.last_put_time = time()
+        self.last_put_time = time_ns()
 
 
 def is_notebook_lab() -> bool:
@@ -197,13 +198,16 @@ def progress_wrapper(
         iteration = next(counter)
 
         if iteration == state.next_put_iteration:
-            time_now = time()
+            time_now = time_ns()
             master_workers_queue.put_nowait((index, WorkerStatus.Running, iteration))
 
             delta_t = time_now - state.last_put_time
             delta_i = iteration - state.last_put_iteration
 
-            state.next_put_iteration += max(int((delta_i / delta_t) * 0.25), 1)
+            state.next_put_iteration += (
+                max(int((delta_i / delta_t) * INTERVAL_NS), 1) if delta_t != 0 else 1
+            )
+
             state.last_put_iteration = iteration
             state.last_put_time = time_now
 


### PR DESCRIPTION
Fix `ZeroDivisionError` on Windows using Progress bars.

This error may happen only on Windows because - maybe - Windows clock is not as precise as Mac/Linux clocks.
2 successive calls to `time_ns` may return the same result, causing the `ZeroDivisionError`.

