### PR TITLE
Add ability to override default MEMORY_FS_ROOT with env var

### DIFF
--- a/pandarallel/core.py
+++ b/pandarallel/core.py
@@ -30,7 +30,7 @@ ON_WINDOWS = os.name == "nt"
 CONTEXT = multiprocessing.get_context("spawn" if ON_WINDOWS else "fork")
 
 # Root of Memory File System
-MEMORY_FS_ROOT = "/dev/shm"
+MEMORY_FS_ROOT = os.environ.get("MEMORY_FS_ROOT", "/dev/shm")
 
 # By default, Pandarallel use all available CPUs
 NB_PHYSICAL_CORES = psutil.cpu_count(logical=False)
@@ -329,7 +329,7 @@ def parallelize_with_memory_file_system(
             except EOFError:
                 # Loading the files failed, this most likely means that there
                 # was some error during processing and the files were never
-                # saved at all. 
+                # saved at all.
                 results_promise.get()
 
                 # If the above statement does not raise an exception, that

--- a/tests/test_pandarallel.py
+++ b/tests/test_pandarallel.py
@@ -1,3 +1,4 @@
+import importlib
 import math
 
 import numpy as np
@@ -168,7 +169,7 @@ def test_dataframe_apply_invalid_function(pandarallel_init, exception):
         raise exception
 
     df = pd.DataFrame(dict(a=[1, 2, 3, 4]))
-    
+
     with pytest.raises(exception):
         df.parallel_apply(f)
 
@@ -356,3 +357,10 @@ def test_dataframe_axis_1_no_reduction(
     res_parallel = df.parallel_apply(func_dataframe_apply_axis_1_no_reduce, axis=1)
 
     assert res.equals(res_parallel)
+
+def test_memory_fs_root_environment_variable(monkeypatch):
+    monkeypatch.setenv("MEMORY_FS_ROOT", "/test")
+    from pandarallel import core
+    importlib.reload(core)
+
+    assert core.MEMORY_FS_ROOT == "/test"


### PR DESCRIPTION
Related to https://github.com/nalepae/pandarallel/issues/127

When running pandarallel in docker, the size of `/dev/shm` is only 64 MB leading to `No space left on device` error.
One option is to set `use_memory_fs` to `False`, but this may have impact on performance.

This PR allows passing of an environment variable `MEMORY_FS_ROOT` to override the default location.