### PR TITLE
Drop Python <3.7 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
 
 [options]
 packages = find:
+python_requires = >=3.7
 install_requires = 
     dill >= 0.3.1
     pandas >= 1


### PR DESCRIPTION
Fix #223 

### Why are we doing this instead of using `time`?
On Windows, using `time` instead of `time_ns` can lead to a weird `ZeroDivisionError` -- see #212.