### PR TITLE
Control number of progress bars

### DIFF
--- a/pandarallel/progress_bars.py
+++ b/pandarallel/progress_bars.py
@@ -55,9 +55,18 @@ def is_notebook_lab() -> bool:
 
 
 class ProgressBarsConsole(ProgressBars):
-    def __init__(self, maxs: List[int], show: bool) -> None:
+    def __init__(self, maxs: List[int], show: bool, count=-1) -> None:
         self.__show = show
-        self.__bars = [[0, max] for max in maxs]
+        num_workers = len(maxs)
+        self.bars_to_show = min(count, num_workers) if count > 0 else num_workers
+        self.map_worker_to_bar = {
+            index: (index % self.bars_to_show) for index in range(num_workers)
+        }
+        bar_maxs = (
+            sum(maxs[k] for k, v in self.map_worker_to_bar.items() if v == bar_index)
+            for bar_index in range(self.bars_to_show)
+        )
+        self.__bars = [[0, max] for max in bar_maxs]
         self.__width = self.__get_width()
 
         self.__lines = self.__update_lines()
@@ -108,7 +117,11 @@ class ProgressBarsConsole(ProgressBars):
         if not self.__show:
             return
 
-        for index, value in enumerate(values):
+        bar_values = [0] * self.bars_to_show
+        for worker_index, value in enumerate(values):
+            bar_values[self.map_worker_to_bar[worker_index]] += value
+
+        for index, value in enumerate(bar_values):
             self.__bars[index][0] = value
 
         self.__remove_displayed_lines()
@@ -119,7 +132,7 @@ class ProgressBarsConsole(ProgressBars):
 
 
 class ProgressBarsNotebookLab(ProgressBars):
-    def __init__(self, maxs: List[int], show: bool) -> None:
+    def __init__(self, maxs: List[int], show: bool, count=-1) -> None:
         """Initialization.
         Positional argument:
         maxs - List containing the max value of each progress bar
@@ -128,6 +141,16 @@ class ProgressBarsNotebookLab(ProgressBars):
 
         if not show:
             return
+
+        num_workers = len(maxs)
+        self.bars_to_show = min(count, num_workers) if count > 0 else num_workers
+        self.map_worker_to_bar = {
+            index: (index % self.bars_to_show) for index in range(num_workers)
+        }
+        bar_maxs = (
+            sum(maxs[k] for k, v in self.map_worker_to_bar.items() if v == bar_index)
+            for bar_index in range(self.bars_to_show)
+        )
 
         from IPython.display import display
         from ipywidgets import HBox, IntProgress, Label, VBox
@@ -139,7 +162,7 @@ class ProgressBarsNotebookLab(ProgressBars):
                     Label("{} / {}".format(0, max)),
                 ]
             )
-            for max in maxs
+            for max in bar_maxs
         ]
 
         display(VBox(self.__bars))
@@ -152,7 +175,11 @@ class ProgressBarsNotebookLab(ProgressBars):
         if not self.__show:
             return
 
-        for index, value in enumerate(values):
+        bar_values = [0] * self.bars_to_show
+        for worker_index, value in enumerate(values):
+            bar_values[self.map_worker_to_bar[worker_index]] += value
+
+        for index, value in enumerate(bar_values):
             bar, label = self.__bars[index].children
 
             bar.value = value
@@ -168,17 +195,17 @@ class ProgressBarsNotebookLab(ProgressBars):
         if not self.__show:
             return
 
-        bar, _ = self.__bars[index].children
+        bar, _ = self.__bars[self.map_worker_to_bar[index]].children
         bar.bar_style = "danger"
 
 
 def get_progress_bars(
-    maxs: List[int], show
+    maxs: List[int], show, count=-1
 ) -> Union[ProgressBarsNotebookLab, ProgressBarsConsole]:
     return (
-        ProgressBarsNotebookLab(maxs, show)
+        ProgressBarsNotebookLab(maxs, show, count)
         if is_notebook_lab()
-        else ProgressBarsConsole(maxs, show)
+        else ProgressBarsConsole(maxs, show, count)
     )
 
 

--- a/tests/test_pandarallel.py
+++ b/tests/test_pandarallel.py
@@ -12,7 +12,7 @@ def df_size(request):
     return request.param
 
 
-@pytest.fixture(params=(False, True))
+@pytest.fixture(params=(False, True, 1))
 def progress_bar(request):
     return request.param
 
@@ -357,6 +357,38 @@ def test_dataframe_axis_1_no_reduction(
     res_parallel = df.parallel_apply(func_dataframe_apply_axis_1_no_reduce, axis=1)
 
     assert res.equals(res_parallel)
+
+
+def test_limit_number_of_progress_bars(
+):
+    from pandarallel.progress_bars import get_progress_bars
+    progresses_length = [2, 3, 2]
+    show_progress_bars = True
+    max_progress_bars = 3
+    progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
+    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    assert len(__bars) == 3
+    max_progress_bars = 4
+    progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
+    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    assert len(__bars) == 3
+    max_progress_bars = 2
+    progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
+    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    assert len(__bars) == 2
+    max_progress_bars = 1
+    progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
+    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    assert len(__bars) == 1
+    max_progress_bars = -100
+    progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
+    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    assert len(__bars) == 3
+    show_progress_bars = False
+    progress_bars = get_progress_bars(progresses_length * 2, show_progress_bars, max_progress_bars)
+    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    assert len(__bars) == 6
+
 
 def test_memory_fs_root_environment_variable(monkeypatch):
     monkeypatch.setenv("MEMORY_FS_ROOT", "/test")

--- a/tests/test_pandarallel.py
+++ b/tests/test_pandarallel.py
@@ -359,34 +359,34 @@ def test_dataframe_axis_1_no_reduction(
     assert res.equals(res_parallel)
 
 
-def test_limit_number_of_progress_bars(
-):
+def test_limit_number_of_progress_bars():
     from pandarallel.progress_bars import get_progress_bars
     progresses_length = [2, 3, 2]
     show_progress_bars = True
     max_progress_bars = 3
     progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
-    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    mangled_attr_name = f"_{progress_bars.__class__.__name__}__bars"
+    __bars = getattr(progress_bars, mangled_attr_name)
     assert len(__bars) == 3
     max_progress_bars = 4
     progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
-    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    __bars = getattr(progress_bars, mangled_attr_name)
     assert len(__bars) == 3
     max_progress_bars = 2
     progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
-    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    __bars = getattr(progress_bars, mangled_attr_name)
     assert len(__bars) == 2
     max_progress_bars = 1
     progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
-    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    __bars = getattr(progress_bars, mangled_attr_name)
     assert len(__bars) == 1
     max_progress_bars = -100
     progress_bars = get_progress_bars(progresses_length, show_progress_bars, max_progress_bars)
-    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    __bars = getattr(progress_bars, mangled_attr_name)
     assert len(__bars) == 3
     show_progress_bars = False
     progress_bars = get_progress_bars(progresses_length * 2, show_progress_bars, max_progress_bars)
-    __bars = getattr(progress_bars, f"_{progress_bars.__class__.__name__}__bars")
+    __bars = getattr(progress_bars, mangled_attr_name)
     assert len(__bars) == 6
 
 


### PR DESCRIPTION
As described in issue #242, this PR proposes adding a way to control the maximum number of progress bars to display that maintains backwards-compatibility with existing code.

Control over the number of progress bars is made through the existing input parameter to `pandarallel.initialize()`:
```
pandarallel.pandarallel.initialize(nb_workers=42, progress_bar=5)
```

Expanded testing is provided by both expanding the number of params to the `pytest.fixture`, `progress_bar()` as well as one new specific unit test.