### PR TITLE
Fix ValueError for Empty DataFrames: Ensure Process Count is at Least 1

### DIFF
--- a/pandarallel/progress_bars.py
+++ b/pandarallel/progress_bars.py
@@ -90,7 +90,10 @@ class ProgressBarsConsole(ProgressBars):
         self.__lines = []
 
     def __update_line(self, done: int, total: int) -> str:
-        percent = done / total
+        if total == 0:
+            percent = 1
+        else:
+            percent = done / total
         bar = (":" * int(percent * 40)).ljust(40, " ")
         percent = round(percent * 100, 2)
         format = " {percent:6.2f}% {bar:s} | {done:8d} / {total:8d} |"
@@ -155,13 +158,17 @@ class ProgressBarsNotebookLab(ProgressBars):
         for index, value in enumerate(values):
             bar, label = self.__bars[index].children
 
+            label.value = "{} / {}".format(value, bar.max)
+            
             bar.value = value
-            bar.description = "{:.2f}%".format(value / bar.max * 100)
 
             if value >= bar.max:
                 bar.bar_style = "success"
 
-            label.value = "{} / {}".format(value, bar.max)
+            if bar.max == 0:
+                bar.max = bar.value = 1
+
+            bar.description = "{:.2f}%".format(bar.value / bar.max * 100)
 
     def set_error(self, index: int) -> None:
         """Set a bar on error"""

--- a/pandarallel/progress_bars.py
+++ b/pandarallel/progress_bars.py
@@ -91,7 +91,7 @@ class ProgressBarsConsole(ProgressBars):
 
     def __update_line(self, done: int, total: int) -> str:
         if total == 0:
-            percent = 1
+            percent = 0
         else:
             percent = done / total
         bar = (":" * int(percent * 40)).ljust(40, " ")
@@ -165,10 +165,8 @@ class ProgressBarsNotebookLab(ProgressBars):
             if value >= bar.max:
                 bar.bar_style = "success"
 
-            if bar.max == 0:
-                bar.max = bar.value = 1
-
-            bar.description = "{:.2f}%".format(bar.value / bar.max * 100)
+            if bar.max != 0:
+                bar.description = "{:.2f}%".format(bar.value / bar.max * 100)
 
     def set_error(self, index: int) -> None:
         """Set a bar on error"""

--- a/pandarallel/utils.py
+++ b/pandarallel/utils.py
@@ -31,6 +31,9 @@ def chunk(nb_item: int, nb_chunks: int, start_offset=0) -> List[slice]:
     >>> chunks
     [slice(0, 26, None), slice(26, 52, None), slice(52, 78, None), slice(78, 103, None)]
     """
+    if nb_item == 0:
+        return [slice(0)]
+    
     if nb_item <= nb_chunks:
         return [slice(max(0, idx - start_offset), idx + 1) for idx in range(nb_item)]
 

--- a/tests/test_pandarallel.py
+++ b/tests/test_pandarallel.py
@@ -210,6 +210,20 @@ def test_dataframe_apply_invalid_axis(pandarallel_init):
 
     with pytest.raises(ValueError):
         df.parallel_apply(lambda x: x, axis="invalid")
+    
+def test_empty_dataframe_apply_axis_0(pandarallel_init, func_dataframe_apply_axis_0):
+    df = pd.DataFrame()
+
+    res = df.apply(func_dataframe_apply_axis_0)
+    res_parallel = df.parallel_apply(func_dataframe_apply_axis_0)
+    assert res.equals(res_parallel)
+
+def test_empty_dataframe_apply_axis_1(pandarallel_init, func_dataframe_apply_axis_1):
+    df = pd.DataFrame()
+
+    res = df.apply(func_dataframe_apply_axis_1)
+    res_parallel = df.parallel_apply(func_dataframe_apply_axis_1)
+    assert res.equals(res_parallel)
 
 
 def test_dataframe_applymap(pandarallel_init, func_dataframe_applymap, df_size):
@@ -233,6 +247,13 @@ def test_series_map(pandarallel_init, func_series_map, df_size):
 
 def test_series_apply(pandarallel_init, func_series_apply, df_size):
     df = pd.DataFrame(dict(a=np.random.rand(df_size) + 1))
+
+    res = df.a.apply(func_series_apply, args=(2,), bias=3)
+    res_parallel = df.a.parallel_apply(func_series_apply, args=(2,), bias=3)
+    assert res.equals(res_parallel)
+
+def test_empty_series_apply(pandarallel_init, func_series_apply):
+    df = pd.DataFrame(dict(a=[]))
 
     res = df.a.apply(func_series_apply, args=(2,), bias=3)
     res_parallel = df.a.parallel_apply(func_series_apply, args=(2,), bias=3)


### PR DESCRIPTION
Since nb_item comes out as 0 for empty dataframes and series, we were returning an empty list from the `chunk` function.
Hence, we were yielding nothing from our `DataType.get_chunks` method which caused our `chunks` list being empty and nb_workers = len(chunks) = 0.

Let me know if this fix seems good enough, and also if we need to add any new tests.

Fixes #115, fixes #141.