### PR TITLE
fix DataFrame.applymap has been deprecated.

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,7 +29,7 @@ get a rough idea of the remaining amount of computation to be done.
 | Without parallelization                                   | With parallelization                                               |
 | --------------------------------------------------------- | ------------------------------------------------------------------ |
 | `df.apply(func)`                                          | `df.parallel_apply(func)`                                          |
-| `df.applymap(func)`                                       | `df.parallel_applymap(func)`                                       |
+| `df.map(func)`                                            | `df.parallel_applymap(func)`                                       |
 | `df.groupby(args).apply(func)`                            | `df.groupby(args).parallel_apply(func)`                            |
 | `df.groupby(args1).col_name.rolling(args2).apply(func)`   | `df.groupby(args1).col_name.rolling(args2).parallel_apply(func)`   |
 | `df.groupby(args1).col_name.expanding(args2).apply(func)` | `df.groupby(args1).col_name.expanding(args2).parallel_apply(func)` |

--- a/docs/examples_mac_linux.ipynb
+++ b/docs/examples_mac_linux.ipynb
@@ -101,10 +101,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DataFrame.applymap"
+    "# DataFrame.map"
    ]
   },
   {
@@ -135,7 +136,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "res = df.applymap(func)"
+    "res = df.map(func)"
    ]
   },
   {

--- a/docs/examples_windows.ipynb
+++ b/docs/examples_windows.ipynb
@@ -131,10 +131,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DataFrame.applymap"
+    "# DataFrame.map"
    ]
   },
   {
@@ -166,7 +167,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "res = df.applymap(func)"
+    "res = df.map(func)"
    ]
   },
   {

--- a/pandarallel/data_types/dataframe.py
+++ b/pandarallel/data_types/dataframe.py
@@ -66,7 +66,7 @@ class DataFrame:
             user_defined_function_kwargs: Dict[str, Any],
             extra: Dict[str, Any],
         ) -> pd.DataFrame:
-            return data.applymap(user_defined_function)
+            return data.map(user_defined_function)
 
         @staticmethod
         def reduce(

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,10 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.9
 install_requires = 
     dill >= 0.3.1
-    pandas >= 1
+    pandas >= 2.1.0
     psutil
 
 [options.packages.find]

--- a/tests/test_pandarallel.py
+++ b/tests/test_pandarallel.py
@@ -212,13 +212,13 @@ def test_dataframe_apply_invalid_axis(pandarallel_init):
         df.parallel_apply(lambda x: x, axis="invalid")
 
 
-def test_dataframe_applymap(pandarallel_init, func_dataframe_applymap, df_size):
+def test_dataframe_map(pandarallel_init, func_dataframe_applymap, df_size):
     df = pd.DataFrame(
         dict(a=np.random.randint(1, 8, df_size), b=np.random.rand(df_size))
     )
     df.index = [item / 10 for item in df.index]
 
-    res = df.applymap(func_dataframe_applymap)
+    res = df.map(func_dataframe_applymap)
     res_parallel = df.parallel_applymap(func_dataframe_applymap)
     assert res.equals(res_parallel)
 


### PR DESCRIPTION
fix issue https://github.com/nalepae/pandarallel/issues/258

/usr/local/lib/python3.12/site-packages/pandarallel/data_types/dataframe.py:69: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
return data.applymap(user_defined_function)

change applymap to map and tests